### PR TITLE
Fix tooltip invalid positioning on dynamic layout

### DIFF
--- a/.changeset/chilled-ants-search.md
+++ b/.changeset/chilled-ants-search.md
@@ -1,0 +1,5 @@
+---
+'@tryrolljs/design-system': patch
+---
+
+Fix tooltip invalid positioning on dynamic layout

--- a/packages/design-system/src/atoms/tooltip/index.web.tsx
+++ b/packages/design-system/src/atoms/tooltip/index.web.tsx
@@ -7,9 +7,11 @@ import {
   offset,
   flip,
   safePolygon,
+  autoUpdate,
+  shift,
+  size,
 } from '@floating-ui/react-dom-interactions'
 import { useState } from 'react'
-import { StyleSheet } from 'react-native'
 import { View } from 'native-base'
 import {
   charcoalBlack,
@@ -20,13 +22,6 @@ import {
 } from '../../styles'
 import { asTextNode } from './utils'
 import { TooltipProps } from '.'
-
-const styles = StyleSheet.create({
-  tooltip: {
-    position: 'absolute',
-    maxWidth: 250,
-  },
-})
 
 export const Tooltip: React.FC<TooltipProps> = ({
   variant = 'light',
@@ -40,10 +35,30 @@ export const Tooltip: React.FC<TooltipProps> = ({
     placement,
     open,
     onOpenChange: setIsOpen,
-    middleware: [offset(8), flip()],
+    middleware: [
+      offset(8),
+      flip(),
+      shift(),
+      size({
+        apply({ availableWidth, availableHeight, elements }) {
+          Object.assign(elements.floating.style, {
+            maxWidth: `${Math.max(availableWidth, 250)}px`,
+            maxHeight: `${availableHeight}px`,
+          })
+        },
+      }),
+    ],
+    // https://floating-ui.com/docs/react-dom#updating
+    whileElementsMounted: (reference_, floating_, update) =>
+      autoUpdate(reference_, floating_, update, {
+        animationFrame: true,
+      }),
   })
   const { getReferenceProps, getFloatingProps } = useInteractions([
-    useHover(context, { handleClose: safePolygon() }),
+    useHover(context, {
+      handleClose: safePolygon(),
+      move: false,
+    }),
     useFocus(context),
   ])
 
@@ -56,7 +71,6 @@ export const Tooltip: React.FC<TooltipProps> = ({
         <FloatingOverlay>
           <View
             style={[
-              styles.tooltip,
               containers.borderRadius,
               containers.shadow,
               padding.ph16,


### PR DESCRIPTION
## What's done

Tooltip has an invalid position when the layout is dynamic. This PR adds re-positioning on each animation frame.

## How to test

1. Change line 103 `src/features/dashboard/index.web.js` in `roll-react-native` to:
```jsx
<Tooltip title="hola mundo!!" variant="dark" open placement="bottom">
  <Header color={colors.darkBlueGrey} weight="bold">
    Social Tokens on Roll
  </Header>
</Tooltip>
```

## Tasks

- [x] Have you written tests for new code (if applicable)?
- [x] Have you tested the changes on all the platforms?
  - [x] iOS
  - [x] Android
  - [x] Web
- [x] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)
