### PR TITLE
fix build leads to empty dist

### DIFF
--- a/.changeset/giant-jobs-nail.md
+++ b/.changeset/giant-jobs-nail.md
@@ -1,0 +1,6 @@
+---
+'@tryrolljs/feature-flag': patch
+'@tryrolljs/design-system': patch
+---
+
+Fix build leads to empty dist

--- a/package.json
+++ b/package.json
@@ -18,5 +18,9 @@
     "@changesets/changelog-github": "^0.4.6",
     "@changesets/cli": "^2.24.3"
   },
-  "packageManager": "yarn@3.2.3"
+  "packageManager": "yarn@3.2.3",
+  "resolutions": {
+    "@types/react": "^17.0.0",
+    "@types/react-dom": "^17.0.0"
+  }
 }

--- a/packages/feature-flag/package.json
+++ b/packages/feature-flag/package.json
@@ -29,6 +29,7 @@
     "jest-environment-jsdom": "^29.0.3",
     "react": ">=17.0.2",
     "react-dom": ">=17.0.2",
+    "rollup": "^2.78.1",
     "rollup-plugin-delete": "^2.0.0"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6500,6 +6500,7 @@ __metadata:
     lodash.groupby: ^4.6.0
     react: ">=17.0.2"
     react-dom: ">=17.0.2"
+    rollup: ^2.78.1
     rollup-plugin-delete: ^2.0.0
   peerDependencies:
     react: ">=17.0.2"
@@ -6932,15 +6933,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:^18.0.0":
-  version: 18.0.6
-  resolution: "@types/react-dom@npm:18.0.6"
-  dependencies:
-    "@types/react": "*"
-  checksum: db571047af1a567631758700b9f7d143e566df939cfe5fbf7535347cc0c726a1cdbb5e3f8566d076e54cf708b6c1166689de194a9ba09ee35efc9e1d45911685
-  languageName: node
-  linkType: hard
-
 "@types/react-modal@npm:^3.13.1":
   version: 3.13.1
   resolution: "@types/react-modal@npm:3.13.1"
@@ -6959,18 +6951,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*":
-  version: 18.0.20
-  resolution: "@types/react@npm:18.0.20"
-  dependencies:
-    "@types/prop-types": "*"
-    "@types/scheduler": "*"
-    csstype: ^3.0.2
-  checksum: f67f5b16efd89e237bf0e40d133218c398cf2a2f81166ce1e9fa32d0df6b869106740983396c51df9708a1b79b2a9d725eda1230cc3064c92d86d9ea6a4b714c
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:^17, @types/react@npm:^17.0.0":
+"@types/react@npm:^17.0.0":
   version: 17.0.50
   resolution: "@types/react@npm:17.0.50"
   dependencies:


### PR DESCRIPTION
## What's done

There are multiple TS issues because the `@types/react` & `@types/react-dom` versions mismatch. Also, `rollup` dependency is missing from the `feature-flag` pkg. This PR fixes both issues.

## How to test

Run `yarn build` in the project root.

## Tasks

- [x] Have you written tests for new code (if applicable)?
- [x] Have you tested the changes on all the platforms?
  - [x] iOS
  - [x] Android
  - [x] Web
- [x] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)
