### PR TITLE
Put build to release

### DIFF
--- a/.changeset/brave-mugs-crash.md
+++ b/.changeset/brave-mugs-crash.md
@@ -1,0 +1,6 @@
+---
+'@tryrolljs/design-system': patch
+'@tryrolljs/feature-flag': patch
+---
+
+Fix empty dist folder

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "test": "yarn workspaces foreach run test",
     "lint": "./packages/cli/bin/roll.js lint",
     "lint:fix": "./packages/cli/bin/roll.js lint --fix",
-    "prerelease": "yarn build",
-    "release": "changeset publish"
+    "release": "yarn build && changeset publish"
   },
   "workspaces": [
     "packages/**"


### PR DESCRIPTION
## What's done

[Lifecycle events don't work in yarn v3](https://github.com/conventional-changelog/standard-version/issues/872). That's why I had to put build to release so that we build the packages before releasing.

## How to test

Run `yarn release`.

## Tasks

- [x] Have you written tests for new code (if applicable)?
- [x] Have you tested the changes on all the platforms?
  - [x] iOS
  - [x] Android
  - [x] Web
- [x] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)
