### PR TITLE
Make AccountDropdown ready for native

### DIFF
--- a/.changeset/proud-carpets-mix.md
+++ b/.changeset/proud-carpets-mix.md
@@ -1,0 +1,5 @@
+---
+'@tryrolljs/design-system': patch
+---
+
+Make AccountDropdown ready for native

--- a/packages/design-system/src/atoms/anchor/index.tsx
+++ b/packages/design-system/src/atoms/anchor/index.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'native-base'
-import { ReactNode } from 'react'
+import { ReactNode, useCallback } from 'react'
+import type { GestureResponderEvent } from 'react-native'
 import { TypographyBase, TypographyBaseProps } from '..'
 import { useTheme } from '../..'
 
@@ -19,18 +20,18 @@ export const Anchor = ({
 }: AnchorProps & Pick<TypographyBaseProps, 'fontSize'>) => {
   const theme = useTheme()
 
+  const handlePress = useCallback(
+    (event?: GestureResponderEvent) => {
+      if (onPress && !href) {
+        event?.preventDefault()
+        onPress?.()
+      }
+    },
+    [onPress, href],
+  )
+
   return (
-    <Link
-      href={href}
-      isExternal={target === '_blank'}
-      onPress={(event) => {
-        console.log(onPress, href)
-        if (onPress && !href) {
-          event?.preventDefault()
-          onPress?.()
-        }
-      }}
-    >
+    <Link href={href} isExternal={target === '_blank'} onPress={handlePress}>
       <TypographyBase color={theme.text.highlight} fontSize={fontSize}>
         {children}
       </TypographyBase>

--- a/packages/design-system/src/atoms/anchor/index.tsx
+++ b/packages/design-system/src/atoms/anchor/index.tsx
@@ -8,7 +8,7 @@ export type AnchorProps = {
   children: ReactNode
   href?: string
   target?: string
-  onPress?: () => void
+  onPress?: (event?: GestureResponderEvent) => void
 }
 
 export const Anchor = ({
@@ -24,7 +24,7 @@ export const Anchor = ({
     (event?: GestureResponderEvent) => {
       if (onPress && !href) {
         event?.preventDefault()
-        onPress?.()
+        onPress(event)
       }
     },
     [onPress, href],

--- a/packages/design-system/src/atoms/anchor/index.tsx
+++ b/packages/design-system/src/atoms/anchor/index.tsx
@@ -1,10 +1,13 @@
+import { Link } from 'native-base'
+import { ReactNode } from 'react'
 import { TypographyBase, TypographyBaseProps } from '..'
 import { useTheme } from '../..'
 
 export type AnchorProps = {
-  children: string
-  href: string
+  children: ReactNode
+  href?: string
   target?: string
+  onPress?: () => void
 }
 
 export const Anchor = ({
@@ -12,14 +15,25 @@ export const Anchor = ({
   href,
   fontSize,
   target = '_blank',
+  onPress,
 }: AnchorProps & Pick<TypographyBaseProps, 'fontSize'>) => {
   const theme = useTheme()
 
   return (
-    <a href={href} target={target}>
+    <Link
+      href={href}
+      isExternal={target === '_blank'}
+      onPress={(event) => {
+        console.log(onPress, href)
+        if (onPress && !href) {
+          event?.preventDefault()
+          onPress?.()
+        }
+      }}
+    >
       <TypographyBase color={theme.text.highlight} fontSize={fontSize}>
         {children}
       </TypographyBase>
-    </a>
+    </Link>
   )
 }

--- a/packages/design-system/src/atoms/tooltip/tooltip.stories.tsx
+++ b/packages/design-system/src/atoms/tooltip/tooltip.stories.tsx
@@ -34,8 +34,8 @@ export const Dark = fromTemplate(Template, {
   variant: 'dark',
   placement: 'bottom-start',
 })
-export const WithManualControl = fromTemplate(ControlledTemplate, {
-  title: 'With maunal control',
+export const Controlled = fromTemplate(ControlledTemplate, {
+  title: 'The tooltip is controlled by the consumer',
   variant: 'dark',
   placement: 'bottom-start',
 })

--- a/packages/design-system/src/atoms/tooltip/tooltip.stories.tsx
+++ b/packages/design-system/src/atoms/tooltip/tooltip.stories.tsx
@@ -10,7 +10,7 @@ const storyConfig = {
 
 const Template = (props: TooltipProps) => <Tooltip {...props}>Hover me</Tooltip>
 
-const WithManualControlTemplate = (props: TooltipProps) => {
+const ControlledTemplate = (props: TooltipProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false)
   return (
     <Tooltip {...props} open={isOpen}>
@@ -34,7 +34,7 @@ export const Dark = fromTemplate(Template, {
   variant: 'dark',
   placement: 'bottom-start',
 })
-export const WithManualControl = fromTemplate(WithManualControlTemplate, {
+export const WithManualControl = fromTemplate(ControlledTemplate, {
   title: 'With maunal control',
   variant: 'dark',
   placement: 'bottom-start',

--- a/packages/design-system/src/atoms/typography/index.tsx
+++ b/packages/design-system/src/atoms/typography/index.tsx
@@ -35,7 +35,7 @@ export const truncateMaxChars = (str: string, maxlimit = 100) => {
 }
 
 type TypographyProps = {
-  children: any
+  children: React.ReactNode
   style?: StyleProp<TextStyle>
   weight?: keyof Weights
   color?: string

--- a/packages/design-system/src/molecules/accountDropdown/accountDropdown.stories.tsx
+++ b/packages/design-system/src/molecules/accountDropdown/accountDropdown.stories.tsx
@@ -1,0 +1,20 @@
+import { action } from '@storybook/addon-actions'
+import { titleBuilder } from '../../../.storybook/utils'
+import { withThemeProvider } from '../../providers/theme/withProvider'
+import { withWeb3Provider } from '../../providers/web3'
+import { AccountDropdown } from '.'
+
+const conf = {
+  title: titleBuilder.molecules('AccountDropdown'),
+  component: AccountDropdown,
+}
+
+export const Default = () => {
+  return withWeb3Provider(
+    withThemeProvider(
+      <AccountDropdown onSwitchAccounts={action('action.onSwitchAccounts')} />,
+    ),
+  )
+}
+
+export default conf

--- a/packages/design-system/src/molecules/accountDropdown/index.tsx
+++ b/packages/design-system/src/molecules/accountDropdown/index.tsx
@@ -1,4 +1,8 @@
-import { Body, margins, useTheme } from '../..'
+import { View } from 'native-base'
+import { StyleSheet } from 'react-native'
+import { Body, Anchor } from '../../atoms'
+import { useTheme } from '../../hooks'
+import { margins, padding, containers } from '../../styles'
 import { etherscanAccountUrl, shortenAddress } from '../../utils/web3'
 import Copy from '../../assets/svg/copy.svg'
 import WalletIcon from '../../assets/svg/wallet.svg'
@@ -6,56 +10,81 @@ import LinkIcon from '../../assets/svg/link.svg'
 import { useEthAddress } from '../../hooks/web3'
 
 type Props = {
-  onSwitchAccounts: () => void
+  onSwitchAccounts?: () => void
 }
 
-export const AccountDropdwn = ({ onSwitchAccounts }: Props) => {
+const styles = StyleSheet.create({
+  container: {
+    minWidth: 320,
+  },
+  address: {
+    maxWidth: 150,
+  },
+})
+
+type SwitchAccountLinkProps = {
+  icon: React.ReactElement
+  title: string
+  onPress?: () => void
+  href?: string
+}
+
+const SwitchAccountLink = ({
+  icon,
+  title,
+  onPress,
+  href,
+}: SwitchAccountLinkProps) => {
+  const theme = useTheme()
+  return (
+    <Anchor target="_blank" href={href} onPress={onPress}>
+      <View style={[containers.row, containers.alignCenter, margins.mh8]}>
+        {icon}
+        <Body
+          onPress={onPress}
+          style={margins.ml4}
+          color={theme.text.highlight}
+        >
+          {title}
+        </Body>
+      </View>
+    </Anchor>
+  )
+}
+
+export const AccountDropdown = ({ onSwitchAccounts }: Props) => {
   const theme = useTheme()
   const address = useEthAddress()
   return (
-    <div className="p-4" style={{ minWidth: 320 }}>
+    <View style={[padding.p8, styles.container]}>
       <Body color={theme.text.secondary}>Connected with MetaMask</Body>
-      <div
-        className="flex flex-row bg-gray-200 p-2 rounded-lg my-2"
-        style={{ maxWidth: 150 }}
+      <View
+        style={[
+          containers.row,
+          styles.address,
+          padding.p8,
+          containers.borderRadiusXL,
+          margins.mv8,
+          { backgroundColor: theme.background.page },
+        ]}
       >
         <Body weight="bold" style={margins.mr8}>
           {shortenAddress(address || '')}
         </Body>
         <Copy />
-      </div>
-      <div className="flex flex-row">
-        <LinkOption
+      </View>
+      <View style={containers.row}>
+        <SwitchAccountLink
           onPress={onSwitchAccounts}
           icon={<WalletIcon />}
           title="Switch Accounts"
         />
-        <a
-          target="_blank"
+        <SwitchAccountLink
+          icon={<LinkIcon />}
+          title="View on Etherscan"
           href={etherscanAccountUrl(address || '')}
-          rel="noreferrer"
-        >
-          <LinkOption icon={<LinkIcon />} title="View on Etherscan" />
-        </a>
-      </div>
-    </div>
-  )
-}
-
-type LinkProps = {
-  icon: React.ReactElement
-  title: string
-  onPress?: () => void
-}
-
-const LinkOption = ({ icon, title, onPress }: LinkProps) => {
-  const theme = useTheme()
-  return (
-    <div className="flex flex-row items-center mr-4">
-      {icon}
-      <Body onPress={onPress} style={margins.ml4} color={theme.text.highlight}>
-        {title}
-      </Body>
-    </div>
+        />
+      </View>
+    </View>
   )
 }

--- a/packages/design-system/src/molecules/connectWeb3Button/index.tsx
+++ b/packages/design-system/src/molecules/connectWeb3Button/index.tsx
@@ -6,7 +6,7 @@ import { Spinner } from '../../atoms'
 import { shortenAddress } from '../../utils/web3'
 import { useEthAddress } from '../../hooks/web3'
 import { Dropdown } from '../dropdown'
-import { AccountDropdwn } from '../accountDropdown'
+import { AccountDropdown } from '../accountDropdown'
 
 export type HandleWeb3Connect = (c: AbstractConnector) => void
 
@@ -41,7 +41,7 @@ export const ConnectWeb3Button = ({
         onMouseLeave={() => setMouseInB(false)}
         open={mouseInA || mouseInB}
         renderDropdown={() => (
-          <AccountDropdwn
+          <AccountDropdown
             onSwitchAccounts={() => {
               setMouseInB(false)
               onPress()


### PR DESCRIPTION
## What's done

Made `AccountDropdown` ready for native. If we want a consistent API for the library, we have to get rid of class names & HTML elements (use `native-base` or `react-native` instead). It'll allow our library to accept the unified `style` prop for both `native` & `web`. Moreover, it'll make more components cross-platform out of the box.

## How to test

1. `yarn start`
2. Go to `Account Dropdwon` story.

## Tasks

- [ ] Have you written tests for new code (if applicable)?
- [x] Have you tested the changes on all the platforms?
  - [x] iOS
  - [x] Android
  - [x] Web
- [x] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)
<img width="1389" alt="Screen Shot 2022-09-27 at 15 25 02" src="https://user-images.githubusercontent.com/17337276/192538721-4cdb2725-4a2f-42ad-aa38-b1ceed80cc3f.png">
