### PR TITLE
Exclude dependencies from dist

### DIFF
--- a/.changeset/nice-baboons-learn.md
+++ b/.changeset/nice-baboons-learn.md
@@ -1,0 +1,5 @@
+---
+'@tryrolljs/design-system': patch
+---
+
+Exclude dependencies from package dist folder

--- a/packages/design-system/rollup.config.js
+++ b/packages/design-system/rollup.config.js
@@ -16,7 +16,7 @@ const doesTargetIncludeNative = (target) =>
   target === 'ios' || target === 'android'
 
 const getExtensions = (target) => {
-  const extensions = ['.ts', '.tsx', '.js', '.jsx', '.es6', '.es', '.mjs']
+  const extensions = ['.ts', '.tsx', '.js', '.jsx']
   const targets = doesTargetIncludeNative(target)
     ? [target, 'native']
     : [target]
@@ -56,9 +56,17 @@ const getConfig = (format, target = 'web', visualize = false) => {
         entryFileNames: makeEntryFileNameGetter(target),
       },
     ],
-    external: [...Object.keys(packageJson.peerDependencies || {})],
+    external: [
+      // We don't need to bundle deps & peer deps
+      ...Object.keys(packageJson.dependencies || {}),
+      ...Object.keys(packageJson.peerDependencies || {}),
+    ],
     plugins: [
       del({ targets: outputDir }),
+      resolve({
+        extensions,
+        moduleDirectories: [],
+      }),
       alias({
         entries: [
           { find: 'react-native$', replacement: 'react-native-web' },
@@ -67,10 +75,6 @@ const getConfig = (format, target = 'web', visualize = false) => {
             replacement: 'react-native-web-linear-gradient',
           },
         ],
-      }),
-      resolve({
-        extensions,
-        moduleDirectories: [],
       }),
       commonjs(),
       babel({


### PR DESCRIPTION
## What's done

There is a weird bug that `react-native-web-linear-gradient` is included in the `dist`. We don't need any library inside `dist`, so I marked both `peerDependencies` & `dependencies` as `external`.

## How to test

1. Run `yarn build` inside the design system.
2. Check that `dist/web/esm/node_modules` contains only `tslib`.

## Tasks

- [ ] Have you written tests for new code (if applicable)?
- [x] Have you tested the changes on all the platforms?
  - [x] iOS
  - [x] Android
  - [x] Web
- [ ] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)
