### PR TITLE
Fix react-native aliases

### DIFF
--- a/.changeset/tidy-bags-kneel.md
+++ b/.changeset/tidy-bags-kneel.md
@@ -1,0 +1,5 @@
+---
+'@tryrolljs/design-system': patch
+---
+
+Fix react-native aliases

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -78,6 +78,7 @@
     "rollup": "^2.78.1",
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-delete": "^2.0.0",
+    "rollup-plugin-node-externals": "^5.0.0",
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-svg": "^2.0.0",
     "rollup-plugin-visualizer": "^5.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6447,6 +6447,7 @@ __metadata:
     rollup: ^2.78.1
     rollup-plugin-copy: ^3.4.0
     rollup-plugin-delete: ^2.0.0
+    rollup-plugin-node-externals: ^5.0.0
     rollup-plugin-postcss: ^4.0.2
     rollup-plugin-svg: ^2.0.0
     rollup-plugin-visualizer: ^5.8.1
@@ -21675,6 +21676,15 @@ __metadata:
   dependencies:
     del: ^5.1.0
   checksum: 8c05b55d0f454e8a487118edfc03aba78092b32fc0bd1fb061617bc7a2a9563a8e9ba64af34dcc0769ff75a89d113108fcc143c6b694901dfd7e1a9b254b106f
+  languageName: node
+  linkType: hard
+
+"rollup-plugin-node-externals@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "rollup-plugin-node-externals@npm:5.0.0"
+  peerDependencies:
+    rollup: ^2.60.0
+  checksum: 92d5744faa159b0b443778a9856437e2d24cba413e4dc3feb97b24a28b5c0de22410cd312a7050bf6d2995f6abf58dc6e8c4231060c90f771263aeb87c684ff5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What's done

Fixed RN aliases:

1. Alias to web if the target is the `web`.
2. Use `externals` Rollup plugin so aliases work correctly.

## How to test

1. Run `yarn build` inside `design-system`.
2. Check that files under `dist/web` don't have `react-native` & `react-native-linear-gradient` imports.
3. Ensure that files under `dist/web` have `react-native-web` & `react-native-web-linear-gradien` imports.
4. Check that files `dist/native` follow the rules above, but in reverse.

## Tasks

- [ ] Have you written tests for new code (if applicable)?
- [x] Have you tested the changes on all the platforms?
  - [x] iOS
  - [x] Android
  - [x] Web
- [ ] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)
