### PR TITLE
Add information component

### DIFF
--- a/.changeset/proud-masks-act.md
+++ b/.changeset/proud-masks-act.md
@@ -1,0 +1,5 @@
+---
+'@tryrolljs/design-system': patch
+---
+
+Add Information component

--- a/packages/design-system/.ondevice/storybook.requires.js
+++ b/packages/design-system/.ondevice/storybook.requires.js
@@ -29,6 +29,7 @@ const getStories = () => {
     require('../src/atoms/tooltip/tooltip.stories.tsx'),
     require('../src/molecules/dropdown/dropdown.stories.tsx'),
     require('../src/molecules/select/select.stories.tsx'),
+    require('../src/molecules/information/information.stories.tsx'),
   ]
 }
 

--- a/packages/design-system/src/molecules/information/index.tsx
+++ b/packages/design-system/src/molecules/information/index.tsx
@@ -1,0 +1,54 @@
+import { useBreakpointValue, View } from 'native-base'
+import { ReactNode, ReactElement, Children, cloneElement } from 'react'
+import { StyleProp, ViewStyle } from 'react-native'
+import { SubHeader } from '../../atoms'
+import { container, margin } from '../../styles'
+
+export interface InformationItemProps {
+  label: string
+  value: ReactNode
+  style?: StyleProp<ViewStyle>
+}
+
+export interface InformationProps {
+  children:
+    | ReactElement<InformationItemProps>
+    | ReactElement<InformationItemProps>[]
+}
+
+export const Information = ({ children }: InformationProps) => {
+  const childrenCount = Children.count(children)
+  return (
+    <View>
+      {Children.map(children, (child, index) => {
+        const isLast = index + 1 === childrenCount
+        return cloneElement(child, {
+          ...child.props,
+          style: [child.props.style, !isLast && margin.mb8],
+        })
+      })}
+    </View>
+  )
+}
+
+const InformationItem = ({ label, value, style }: InformationItemProps) => {
+  const responsiveStyle = useBreakpointValue({
+    base: undefined,
+    lg: container.row,
+  })
+  const labelResponsiveStyle = useBreakpointValue({
+    base: margin.mb4,
+    lg: undefined,
+  })
+
+  return (
+    <View style={[responsiveStyle, container.justifySpaceBetween, style]}>
+      <SubHeader style={labelResponsiveStyle} weight="semiBold">
+        {label}
+      </SubHeader>
+      {value}
+    </View>
+  )
+}
+
+Information.Item = InformationItem

--- a/packages/design-system/src/molecules/information/information.stories.tsx
+++ b/packages/design-system/src/molecules/information/information.stories.tsx
@@ -1,0 +1,44 @@
+import { titleBuilder, fromTemplate } from '../../../.storybook/utils'
+import { Caption } from '../../atoms'
+import { Information, InformationProps } from '.'
+
+const storyConfig = {
+  title: titleBuilder.molecules('Information'),
+  component: Information,
+}
+
+const Template = (props: InformationProps) => <Information {...props} />
+
+export const Default = fromTemplate(Template, {
+  children: [
+    <Information.Item
+      key="creatorWallet"
+      label="Creator Wallet (90%)"
+      value={
+        <Caption>
+          0x0e22f790d11cf748CF2e3Bd29E69a0efa928Ca2f - Roll wallet
+        </Caption>
+      }
+    />,
+    <Information.Item
+      key="referralWallet"
+      label="Referral Wallet (9%)"
+      value={
+        <Caption>
+          0x7302395Da810aB151913A0563Bd519b11ec3caC0 - External wallet
+        </Caption>
+      }
+    />,
+    <Information.Item
+      key="rollWallet"
+      label="Roll Wallet (1%)"
+      value={
+        <Caption>
+          0xAe4B45B64B16F772165E997181b35441c1C62CB7 - Roll wallet
+        </Caption>
+      }
+    />,
+  ],
+})
+
+export default storyConfig


### PR DESCRIPTION
## What's done

Added `Information` component.

## How to test

1. Run storybooks for all the platforms.
2. Check that the rendered result matches the screenshots below.

## Tasks

- [ ] Have you written tests for new code (if applicable)?
- [x] Have you tested the changes on all the platforms?
  - [x] iOS
  - [x] Android
  - [x] Web
- [x] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)

<img width="1043" alt="Screen Shot 2022-10-25 at 14 54 02" src="https://user-images.githubusercontent.com/17337276/197778906-5859b2d7-98dc-4746-aecd-47b6cf0dbf68.png">
<img width="564" alt="Screen Shot 2022-10-25 at 14 54 07" src="https://user-images.githubusercontent.com/17337276/197778916-a94190bb-505c-4b41-af23-9a5a501a53f0.png">
<img width="677" alt="Screen Shot 2022-10-25 at 14 54 55" src="https://user-images.githubusercontent.com/17337276/197778925-7b35aeea-e201-4029-8f4f-bc6f0b87f1df.png">
