### PR TITLE
use promise all settled polyfill

### DIFF
--- a/.changeset/old-teachers-notice.md
+++ b/.changeset/old-teachers-notice.md
@@ -1,0 +1,5 @@
+---
+'@tryrolljs/feature-flag': patch
+---
+
+Use Promise.allSettled polyfill

--- a/packages/feature-flag/src/index.tsx
+++ b/packages/feature-flag/src/index.tsx
@@ -23,6 +23,16 @@ const FeatureFlagContext = createContext<{
   loading: boolean
 }>({ flags: {}, loading: true })
 
+// Using polyfill for Promise.allSettled
+const allSettled = <T extends unknown>(promises: Promise<T>[]) =>
+  Promise.all(
+    promises.map((promise) =>
+      promise
+        .then((value) => ({ status: 'fulfilled', value }))
+        .catch((reason) => ({ status: 'rejected', reason })),
+    ),
+  )
+
 export const FeatureFlagProvider = ({
   flags,
   children,
@@ -91,9 +101,11 @@ export const FeatureFlagProvider = ({
     const promises = allAsyncFeatureFlags.map((featureFlag) =>
       featureFlag.value(),
     )
-    const settledPromises = await Promise.allSettled(promises)
+    4
 
-    return settledPromises.reduce((acc, result, index) => {
+    return (
+      await allSettled<StaticFeatureFlagValue | FeatureFlagMap>(promises)
+    ).reduce((acc, result, index) => {
       if (result.status === 'fulfilled') {
         const correspondingFeatureFlag = allAsyncFeatureFlags[index]
 


### PR DESCRIPTION
## What's done

- Used polyfill for `Promise.allSettled` because it's not supported in RN.

## How to test

## Tasks

- [ ] Have you written tests for new code (if applicable)?
- [x] Have you tested the changes on all the platforms?
  - [x] iOS
  - [x] Android
  - [x] Web
- [ ] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)
