### PR TITLE
Fix select search & allow information to accept null children

### DIFF
--- a/.changeset/dry-items-think.md
+++ b/.changeset/dry-items-think.md
@@ -1,0 +1,6 @@
+---
+'@tryrolljs/design-system': patch
+---
+
+- Allow null children for Information component
+- Fix search & clear functionality for Select

--- a/packages/design-system/src/atoms/popover/index.web.tsx
+++ b/packages/design-system/src/atoms/popover/index.web.tsx
@@ -33,10 +33,14 @@ export const Popover = ({
       flip(),
       shift(),
       size({
-        apply({ availableWidth, availableHeight, elements }) {
+        apply({ rects, availableWidth, availableHeight, elements }) {
           Object.assign(elements.floating.style, {
-            maxWidth: `${availableWidth}px`,
-            width: matchReferenceWidth ? `${availableWidth}px` : undefined,
+            maxWidth: matchReferenceWidth
+              ? `${rects.reference.width}px`
+              : `${availableWidth}px`,
+            width: matchReferenceWidth
+              ? `${rects.reference.width}px`
+              : undefined,
             maxHeight: `${availableHeight}px`,
           })
         },

--- a/packages/design-system/src/molecules/information/index.tsx
+++ b/packages/design-system/src/molecules/information/index.tsx
@@ -12,8 +12,8 @@ export interface InformationItemProps {
 
 export interface InformationProps {
   children:
-    | ReactElement<InformationItemProps>
-    | ReactElement<InformationItemProps>[]
+    | (ReactElement<InformationItemProps> | null)
+    | (ReactElement<InformationItemProps> | null)[]
 }
 
 export const Information = ({ children }: InformationProps) => {
@@ -22,10 +22,12 @@ export const Information = ({ children }: InformationProps) => {
     <View>
       {Children.map(children, (child, index) => {
         const isLast = index + 1 === childrenCount
-        return cloneElement(child, {
-          ...child.props,
-          style: [child.props.style, !isLast && margin.mb8],
-        })
+        return child
+          ? cloneElement(child, {
+              ...child.props,
+              style: [child.props.style, !isLast && margin.mb8],
+            })
+          : child
       })}
     </View>
   )

--- a/packages/design-system/src/molecules/select/select.stories.tsx
+++ b/packages/design-system/src/molecules/select/select.stories.tsx
@@ -1,3 +1,4 @@
+import { View } from 'native-base'
 import { titleBuilder, fromTemplate } from '../../../.storybook/utils'
 import { Select, SelectProps } from '.'
 
@@ -6,7 +7,11 @@ const storyConfig = {
   component: Select,
 }
 
-const Template = (props: SelectProps) => <Select {...props} />
+const Template = (props: SelectProps) => (
+  <View style={{ maxWidth: 300 }}>
+    <Select {...props} />
+  </View>
+)
 
 export const Default = fromTemplate(Template, {
   placeholder: 'Select an option',

--- a/packages/design-system/src/molecules/select/select.test.tsx
+++ b/packages/design-system/src/molecules/select/select.test.tsx
@@ -35,4 +35,52 @@ describe('Select', () => {
     )
     expect(onChange).toHaveBeenCalledWith('1')
   })
+
+  it('filters options', async () => {
+    const onChange = jest.fn()
+    const options = [
+      { name: 'Option #1', value: '1' },
+      { name: 'Option #2', value: '2' },
+      { name: 'Option #3', value: '3' },
+    ]
+    render(<Select options={options} onChange={onChange} />, {
+      wrapper: TryrollTestProvider,
+    })
+
+    const selectInput = await screen.findByTestId('selectInput')
+    expect(selectInput).toBeDefined()
+
+    fireEvent(selectInput, 'onFocus')
+
+    fireEvent.changeText(selectInput, '#2')
+
+    const option2 = await screen.findByTestId('selectOption__2')
+    expect(option2).toBeDefined()
+    const option1 = screen.queryByTestId('selectOption__1')
+    const option3 = screen.queryByTestId('selectOption__3')
+    expect(option1).toBeNull()
+    expect(option3).toBeNull()
+  })
+
+  it('clears value', async () => {
+    const onChange = jest.fn()
+    const options = [
+      { name: 'Option #1', value: '1' },
+      { name: 'Option #2', value: '2' },
+      { name: 'Option #3', value: '3' },
+    ]
+    render(<Select options={options} onChange={onChange} defaultValue="1" />, {
+      wrapper: TryrollTestProvider,
+    })
+
+    const selectInput = await screen.findByTestId('selectInput')
+    expect(selectInput).toBeDefined()
+
+    fireEvent(selectInput, 'onFocus')
+
+    // Simulate backspace change
+    fireEvent.changeText(selectInput, 'Option #')
+
+    expect(selectInput.props.value).toBe('')
+  })
 })


### PR DESCRIPTION
## What's done

- Fixed Select search functionality.
- Allowed to clear the Select field.
- Fixed `Popover`'s `matchReferenceWidth` property to work correctly.
- Allowed `Information` to accept `null` children.

## How to test

1. Run storybooks for all the platforms.
2. Check `Select` component to work correctly.

## Tasks

- [x] Have you written tests for new code (if applicable)?
- [x] Have you tested the changes on all the platforms?
  - [x] iOS
  - [x] Android
  - [x] Web
- [x] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)
