### PR TITLE
Fix token select console error

### DIFF
--- a/.changeset/nasty-snakes-wave.md
+++ b/.changeset/nasty-snakes-wave.md
@@ -1,0 +1,5 @@
+---
+'@tryrolljs/design-system': patch
+---
+
+Fix TokenSelect error when uncontrolled input becomes controlled

--- a/packages/design-system/src/organisms/tokenSelect/index.tsx
+++ b/packages/design-system/src/organisms/tokenSelect/index.tsx
@@ -41,7 +41,8 @@ export const TokenSelect = ({
 }: TokenSelectProps) => {
   const theme = useTheme()
   const [value, setValue] = useState(defaultValue)
-  const inputValue = options.find((option) => option.value === value)?.name
+  const selectedOption = options.find((option) => option.value === value)
+  const inputValue = selectedOption?.name ?? ''
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [searchInputValue, setSearchInputValue] = useState('')
 


### PR DESCRIPTION
## What's done

- Fixed fallback value for `TokenSelect`'s input to get rid of the error in the console saying that we can't convert an uncontrolled input to the controlled state.

## How to test

1. Run storybook.
2. Go to `TokenSelect`.
3. Select a token.
4. Ensure that there is no errors in the console.

## Tasks

- [ ] Have you written tests for new code (if applicable)?
- [x] Have you tested the changes on all the platforms?
  - [x] iOS
  - [x] Android
  - [x] Web
- [ ] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)
