### PR TITLE
Use post payload instead of query params

### DIFF
--- a/.changeset/quick-peaches-notice.md
+++ b/.changeset/quick-peaches-notice.md
@@ -1,0 +1,5 @@
+---
+'@tryrolljs/api': patch
+---
+
+Update request token to use post payload instead of query params

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -29,17 +29,17 @@ export const requestToken = async ({
   clientId,
 }: RequestTokenArgs) => {
   try {
-    const queryString = qs.stringify({
+    const body = {
       code,
       refresh_token: refreshToken,
       grant_type: grantType,
       redirect_uri: redirectUri,
       client_id: clientId,
-    })
+    }
 
     return await axios.post<RequestTokenResponseData>(
-      `${issuerUrl}/token?${queryString}`,
-      undefined,
+      `${issuerUrl}/token`,
+      body,
       {
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',


### PR DESCRIPTION
## What's done

- Use post payload instead of query params for `/token` request.

## How to test

## Tasks

- [ ] Have you written tests for new code (if applicable)?
- [ ] Have you tested the changes on all the platforms?
  - [ ] iOS
  - [ ] Android
  - [ ] Web
- [ ] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)
