### PR TITLE
Refactor client & extend from event emitter

### DIFF
--- a/.changeset/smart-falcons-refuse.md
+++ b/.changeset/smart-falcons-refuse.md
@@ -1,0 +1,5 @@
+---
+'@tryrolljs/api': patch
+---
+
+Refactor client & extend from event emitter

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -14,6 +14,7 @@
     "axios": "^1.2.2",
     "better-queue": "^3.8.12",
     "better-queue-memory": "^1.0.4",
+    "events": "^3.3.0",
     "lodash.groupby": "^4.6.0",
     "qs": "^6.11.0"
   },

--- a/packages/api/src/client/types.ts
+++ b/packages/api/src/client/types.ts
@@ -1,0 +1,33 @@
+import { AxiosResponse } from 'axios'
+
+export enum Event {
+  Unauthorized = 'unauthorized',
+}
+
+export interface Request {
+  url: string
+  method: string
+  body?: object
+  authorization?: boolean
+  override?: { headers?: Record<string, unknown> }
+}
+
+export type AnyHandler = () => unknown | Promise<unknown>
+
+export type ResponseHandler = <T>(
+  response: AxiosResponse<T>,
+) => unknown | Promise<unknown>
+
+export interface Config {
+  getClientVersion: () => string
+  getAuthorization: () => string | undefined
+  getAuthorizationExpired: () => boolean
+}
+
+export interface Parsers {
+  error: <T>(response: AxiosResponse<T>) => unknown | Promise<unknown>
+}
+
+export interface Handlers {
+  refresh: () => unknown | Promise<unknown>
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7031,6 +7031,7 @@ __metadata:
     babel-jest: ^29.3.1
     better-queue: ^3.8.12
     better-queue-memory: ^1.0.4
+    events: ^3.3.0
     jest: ^29.0.3
     jest-environment-jsdom: ^29.0.3
     lodash.groupby: ^4.6.0
@@ -13718,7 +13719,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"events@npm:^3.0.0, events@npm:^3.2.0":
+"events@npm:^3.0.0, events@npm:^3.2.0, events@npm:^3.3.0":
   version: 3.3.0
   resolution: "events@npm:3.3.0"
   checksum: f6f487ad2198aa41d878fa31452f1a3c00958f46e9019286ff4787c84aac329332ab45c9cdc8c445928fc6d7ded294b9e005a7fce9426488518017831b272780


### PR DESCRIPTION
## What's done

- Refactored client to decrease constructor arguments.
- Extended client from event emitter to react on 401.

## How to test

- `yarn test`.

## Tasks

- [x] Have you written tests for new code (if applicable)?
- [ ] Have you tested the changes on all the platforms?
  - [ ] iOS
  - [ ] Android
  - [ ] Web
- [ ] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)
