### PR TITLE
fix: Prevent scroll when modal is open

### DIFF
--- a/.changeset/shaggy-geese-attack.md
+++ b/.changeset/shaggy-geese-attack.md
@@ -1,0 +1,5 @@
+---
+'@tryrolljs/design-system': patch
+---
+
+Prevent scroll when modal is open

--- a/packages/design-system/ios/Podfile.lock
+++ b/packages/design-system/ios/Podfile.lock
@@ -308,7 +308,7 @@ PODS:
     - React-Core
   - react-native-safe-area-context (3.4.1):
     - React-Core
-  - react-native-slider (4.3.2):
+  - react-native-slider (4.4.0):
     - React-Core
   - React-perflogger (0.70.3)
   - React-RCTActionSheet (0.70.3):
@@ -376,11 +376,11 @@ PODS:
     - React-jsi (= 0.70.3)
     - React-logger (= 0.70.3)
     - React-perflogger (= 0.70.3)
-  - RNCAsyncStorage (1.17.10):
+  - RNCAsyncStorage (1.17.11):
     - React-Core
-  - RNDateTimePicker (6.5.2):
+  - RNDateTimePicker (6.7.1):
     - React-Core
-  - RNSVG (12.4.4):
+  - RNSVG (12.5.0):
     - React-Core
   - SocketRocket (0.6.0)
   - Yoga (1.14.0)
@@ -595,7 +595,7 @@ SPEC CHECKSUMS:
   React-logger: cffcc09e8aba8a3014be8d18da7f922802e9f19e
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
   react-native-safe-area-context: 9e40fb181dac02619414ba1294d6c2a807056ab9
-  react-native-slider: e540525ea731783850802b7af457d8551edb0711
+  react-native-slider: d2938a12c4e439a227c70eec65d119136eb4aeb5
   React-perflogger: 082b4293f0b3914ff41da35a6c06ac4490fcbcc8
   React-RCTActionSheet: 83da3030deb5dea54b398129f56540a44e64d3ae
   React-RCTAnimation: bac3a4f4c0436554d9f7fbb1352a0cdcb1fb0f1c
@@ -608,9 +608,9 @@ SPEC CHECKSUMS:
   React-RCTVibration: b9a58ffdd18446f43d493a4b0ecd603ee86be847
   React-runtimeexecutor: e9b1f9310158a1e265bcdfdfd8c62d6174b947a2
   ReactCommon: 01064177e66d652192c661de899b1076da962fd9
-  RNCAsyncStorage: 0c357f3156fcb16c8589ede67cc036330b6698ca
-  RNDateTimePicker: 3f32aa2247836c12618d346113e5e82ea60ddd9c
-  RNSVG: ecd661f380a07ba690c9c5929c475a44f432d674
+  RNCAsyncStorage: 8616bd5a58af409453ea4e1b246521bb76578d60
+  RNDateTimePicker: 0530a73a6f3a1a85814cbde0802736993b9e675e
+  RNSVG: 6adc5c52d2488a476248413064b7f2832e639057
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: 2ed968a4f060a92834227c036279f2736de0fce3
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/packages/design-system/src/hooks/modal.ts
+++ b/packages/design-system/src/hooks/modal.ts
@@ -1,11 +1,77 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useState, useRef } from 'react'
+import { Platform } from 'react-native'
+
+const useScrollBlock = () => {
+  const scroll = useRef(false)
+
+  const blockScroll = () => {
+    if (typeof document === 'undefined') return
+
+    const html = document.documentElement
+    const { body } = document
+
+    if (!body || !body.style || scroll.current) return
+
+    const scrollBarWidth = window.innerWidth - html.clientWidth
+    const bodyPaddingRight =
+      parseInt(
+        window.getComputedStyle(body).getPropertyValue('padding-right'),
+      ) || 0
+
+    /**
+     * 1. Fixes a bug in iOS and desktop Safari whereby setting
+     *    `overflow: hidden` on the html/body does not prevent scrolling.
+     * 2. Fixes a bug in desktop Safari where `overflowY` does not prevent
+     *    scroll if an `overflow-x` style is also applied to the body.
+     */
+    html.style.position = 'relative' /* [1] */
+    body.style.position = 'relative' /* [1] */
+    html.style.overflow = 'hidden' /* [2] */
+    body.style.overflow = 'hidden' /* [2] */
+    body.style.paddingRight = `${bodyPaddingRight + scrollBarWidth}px`
+
+    scroll.current = true
+  }
+
+  const allowScroll = () => {
+    if (typeof document === 'undefined') return
+
+    const html = document.documentElement
+    const { body } = document
+
+    if (!body || !body.style || !scroll.current) return
+
+    html.style.position = ''
+    html.style.overflow = ''
+    body.style.position = ''
+    body.style.overflow = ''
+    body.style.paddingRight = ''
+
+    scroll.current = false
+  }
+
+  return [blockScroll, allowScroll]
+}
 
 export const useModal = () => {
   const [isOpen, setIsOpen] = useState(false)
-
-  const open = useCallback(() => setIsOpen(true), [])
-  const close = useCallback(() => setIsOpen(false), [])
-  const toggle = useCallback(() => setIsOpen(!isOpen), [isOpen])
+  const [blockScroll, allowScroll] = useScrollBlock()
+  const open = useCallback(() => {
+    if (Platform.OS === 'web') {
+      blockScroll()
+    }
+    setIsOpen(true)
+  }, [blockScroll])
+  const close = useCallback(() => {
+    if (Platform.OS === 'web') {
+      allowScroll()
+    }
+    setIsOpen(false)
+  }, [allowScroll])
+  const toggle = useCallback(() => {
+    if (isOpen) return close()
+    return open()
+  }, [isOpen, open, close])
 
   return {
     isOpen,

--- a/packages/design-system/src/organisms/modal/modal.stories.tsx
+++ b/packages/design-system/src/organisms/modal/modal.stories.tsx
@@ -1,4 +1,5 @@
 import { action } from '@storybook/addon-actions'
+import { ScrollView, View } from 'native-base'
 import { titleBuilder, fromTemplate } from '../../../.storybook/utils'
 import { Body, Button, Header } from '../../atoms'
 import { useModal } from '../../hooks'
@@ -14,12 +15,13 @@ const storyConfig = {
 const Template = ({ size, children }: ModalProps) => {
   const { toggle, isOpen, close } = useModal()
   return (
-    <>
+    <ScrollView>
       <Button variant="primary" onPress={toggle} title="Toggle" />
+      <View style={{ height: 2000 }} />
       <Modal isOpen={isOpen} onClose={close} size={size}>
         {children}
       </Modal>
-    </>
+    </ScrollView>
   )
 }
 


### PR DESCRIPTION
## What's done
When the modal is open the scroll background will be blocked.
## How to test

## Tasks

- [ ] Have you written tests for new code (if applicable)?
- [x] Have you tested the changes on all the platforms?
  - [x] iOS
  - [ ] Android
  - [x] Web
- [x] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)
