### PR TITLE
feat: add mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,4 @@
+Diego Gonzalez <diego@tryroll.com> <106546965+diegonzs-roll@users.noreply.github.com>
+Diego Gonzalez <diego@tryroll.com> <diego.ags04@gmail.com>
+Teimur Gasanov <teimur@tryroll.com> <teymurgg321@gmail.com>
+github-actions[bot] <github-actions[bot]@users.noreply.github.com> <41898282+github-actions[bot]@users.noreply.github.com>


### PR DESCRIPTION
## What's done

This change adds a `.mailmap` file in the root of the repository, which is used by `git-shortlog` and friends to aggregate contribution information from different commit authors, which is useful when an individual has used multiple names or email addresses in different commits.

## How to test

```
git shortlog -sne
```

## Tasks

- [ ] Have you written tests for new code (if applicable)?
- [ ] Have you tested the changes on all the platforms?
  - [ ] iOS
  - [ ] Android
  - [ ] Web
- [ ] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)