### PR TITLE
Add base API url support

### DIFF
--- a/.changeset/clever-panthers-judge.md
+++ b/.changeset/clever-panthers-judge.md
@@ -1,0 +1,5 @@
+---
+'@tryrolljs/api': patch
+---
+
+Add base API url support

--- a/packages/api/@types/better-memory-queue/index.d.ts
+++ b/packages/api/@types/better-memory-queue/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'better-queue-memory'

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -5,3 +5,28 @@
 ```sh
 yarn add @tryrolljs/api
 ```
+
+## Setup
+
+The library uses [better-queue](https://www.npmjs.com/package/better-queue) that is a browser compatible Node package. It requires [util](https://www.npmjs.com/package/util) to be installed when used within browser environment.
+
+### CRA
+
+If you use create-react-app, you have to
+
+1. Install [craco](https://www.npmjs.com/package/@craco/craco).
+2. Update `package.json` to use `craco` instead of `react-scripts` in the `scripts` section.
+3. Create a new `craco.config.js` file with the following content:
+```js
+module.exports = {
+  webpack: {
+    configure: {
+      resolve: {
+        fallback: {
+          util: require.resolve("util"),
+        },
+      },
+    },
+  },
+};
+``` 

--- a/packages/api/src/client/client.ts
+++ b/packages/api/src/client/client.ts
@@ -1,10 +1,10 @@
 import 'setimmediate'
 import { EventEmitter } from 'events'
 import Queue from 'better-queue'
-// @ts-ignore
 import MemoryStore from 'better-queue-memory'
 import axios from 'axios'
 import { Config, Parsers, Handlers, Request, Event } from './types'
+import { concatBaseAndRelativeUrls, isAbsoluteUrl } from './utils'
 
 export default class Client extends EventEmitter {
   private config: Config
@@ -34,7 +34,7 @@ export default class Client extends EventEmitter {
   private getHeaders = (authorization = false) => {
     const headers = {
       'Content-Type': 'application/json',
-      'X-Client-Version': this.config.getClientVersion(),
+      'X-Client-Version': this.config.getClientVersion?.(),
       Authorization: undefined as string | undefined,
     }
 
@@ -60,6 +60,11 @@ export default class Client extends EventEmitter {
 
     if (override?.headers) {
       options.headers = { ...options.headers, ...override.headers }
+    }
+
+    if (this.config.getApiUrl && !isAbsoluteUrl(url)) {
+      const apiUrl = this.config.getApiUrl()
+      options.url = concatBaseAndRelativeUrls(apiUrl, url)
     }
 
     return options

--- a/packages/api/src/client/types.ts
+++ b/packages/api/src/client/types.ts
@@ -19,9 +19,10 @@ export type ResponseHandler = <T>(
 ) => unknown | Promise<unknown>
 
 export interface Config {
-  getClientVersion: () => string
   getAuthorization: () => string | undefined
   getAuthorizationExpired: () => boolean
+  getApiUrl?: () => string
+  getClientVersion?: () => string
 }
 
 export interface Parsers {

--- a/packages/api/src/client/utils.ts
+++ b/packages/api/src/client/utils.ts
@@ -1,0 +1,14 @@
+export const isAbsoluteUrl = (url: string) => /^https?:\/\//i.test(url)
+
+export const concatBaseAndRelativeUrls = (
+  baseUrl: string,
+  relativeUrl: string,
+) => {
+  const isRelativeUrlStartsWithSlash = relativeUrl.startsWith('/')
+
+  if (isRelativeUrlStartsWithSlash) {
+    return baseUrl + relativeUrl
+  }
+
+  return `${baseUrl}/${relativeUrl}`
+}

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -16,6 +16,6 @@
     "strict": true,
     "target": "es5"
   },
-  "include": ["src"],
+  "include": ["@types", "src"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## What's done

- Added base API url support by the client.
- Made `getClientVersion` optional.

## How to test

`yarn test`

## Tasks

- [x] Have you written tests for new code (if applicable)?
- [ ] Have you tested the changes on all the platforms?
  - [ ] iOS
  - [ ] Android
  - [ ] Web
- [ ] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)
