### PR TITLE
Use removeItem instead of setItem to undefined in storage

### DIFF
--- a/.changeset/gold-eggs-kiss.md
+++ b/.changeset/gold-eggs-kiss.md
@@ -1,0 +1,5 @@
+---
+'@tryrolljs/sdk': patch
+---
+
+Use removeItem instead of setItem to undefined in storage

--- a/packages/sdk/src/auth/sdk.test.ts
+++ b/packages/sdk/src/auth/sdk.test.ts
@@ -15,7 +15,7 @@ const config = {
 const storage = {
   setItem: jest.fn(),
   getItem: jest.fn(),
-  clear: jest.fn(),
+  removeItem: jest.fn(),
 }
 
 const mockRequestToken = auth.requestToken as jest.Mock
@@ -217,7 +217,7 @@ describe('AuthSDK', () => {
 
     await sdk.clear()
     expect(sdk.getAccessToken()).toBe(undefined)
-    expect(storage.setItem).toHaveBeenCalledWith('ROLL_AUTHSDK_AUTH', undefined)
+    expect(storage.removeItem).toHaveBeenCalledWith('ROLL_AUTHSDK_AUTH')
 
     mockDateConstructor.mockRestore()
   })

--- a/packages/sdk/src/auth/sdk.ts
+++ b/packages/sdk/src/auth/sdk.ts
@@ -45,7 +45,7 @@ class AuthSDK extends EventEmitter {
           }),
         )
       } else {
-        await this.storage.setItem(STORAGE_KEY, undefined)
+        await this.storage.removeItem(STORAGE_KEY)
       }
     })
   }

--- a/packages/sdk/src/auth/types.ts
+++ b/packages/sdk/src/auth/types.ts
@@ -9,8 +9,9 @@ export interface OauthConfig {
 }
 
 export interface Storage {
-  setItem(key: string, value: string | undefined): void | Promise<void>
+  setItem(key: string, value: string): void | Promise<void>
   getItem(key: string): string | undefined | Promise<string | undefined>
+  removeItem(key: string): void | Promise<void>
 }
 
 export type AuthState = auth.types.RequestTokenResponseData & {


### PR DESCRIPTION
## What's done

- Used `removeItem` instead of `setItem` to clear the storage

## How to test

`yarn test`

## Tasks

- [x] Have you written tests for new code (if applicable)?
- [ ] Have you tested the changes on all the platforms?
  - [ ] iOS
  - [ ] Android
  - [ ] Web
- [ ] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)
