### PR TITLE
Add input disabled state

### DIFF
--- a/.changeset/big-dragons-shave.md
+++ b/.changeset/big-dragons-shave.md
@@ -1,0 +1,5 @@
+---
+'@tryrolljs/design-system': patch
+---
+
+Add disabled state for Input

--- a/.changeset/big-dragons-shave.md
+++ b/.changeset/big-dragons-shave.md
@@ -2,4 +2,5 @@
 '@tryrolljs/design-system': patch
 ---
 
-Add disabled state for Input
+- Added disabled state for Input
+- Added number Input type

--- a/packages/design-system/src/atoms/input/index.tsx
+++ b/packages/design-system/src/atoms/input/index.tsx
@@ -1,6 +1,7 @@
 import { View } from 'native-base'
 import { forwardRef, ReactNode, useEffect, useRef } from 'react'
 import { Animated, TextInput, TextInputProps } from 'react-native'
+import { useTheme } from '../../hooks'
 import {
   charcoalBlack,
   container,
@@ -11,6 +12,7 @@ import {
 
 export interface InputProps extends TextInputProps {
   right?: ReactNode
+  disabled?: boolean
 }
 
 const styles = makeStyles({
@@ -39,6 +41,7 @@ export const Input = forwardRef<TextInput, InputProps>(
       right,
       placeholder,
       value,
+      disabled = false,
       editable = true,
       onFocus,
       onBlur,
@@ -46,9 +49,12 @@ export const Input = forwardRef<TextInput, InputProps>(
     },
     ref,
   ) => {
+    const theme = useTheme()
     const isEmpty = !value || value.length === 0
     const labelTop = useRef(new Animated.Value(0)).current
     const labelFontSize = useRef(new Animated.Value(14)).current
+
+    const isEnabledAndEditable = !disabled && editable
 
     const scaleLabelDown = () => {
       Animated.parallel([
@@ -82,7 +88,7 @@ export const Input = forwardRef<TextInput, InputProps>(
 
     const handleFocus: InputProps['onFocus'] = (event) => {
       onFocus?.(event)
-      if (editable) {
+      if (isEnabledAndEditable) {
         scaleLabelDown()
       }
     }
@@ -101,6 +107,19 @@ export const Input = forwardRef<TextInput, InputProps>(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isEmpty])
 
+    const disabledInputStyle = disabled
+      ? {
+          backgroundColor: theme.background.tertiary,
+          borderColor: theme.background.tertiary,
+          opacity: 0.5,
+        }
+      : undefined
+    const disabledLabelStyle = disabled
+      ? {
+          opacity: 0.5,
+        }
+      : undefined
+
     return (
       <View>
         <TextInput
@@ -111,6 +130,7 @@ export const Input = forwardRef<TextInput, InputProps>(
             styles.input,
             padding.ph16,
             placeholder ? padding.pt24 : undefined,
+            disabledInputStyle,
             padding.pv8,
             container.borderRadiusSM,
             container.fullWidth,
@@ -118,7 +138,7 @@ export const Input = forwardRef<TextInput, InputProps>(
           value={value}
           onFocus={handleFocus}
           onBlur={handleBlur}
-          editable={editable}
+          editable={isEnabledAndEditable}
         />
         {right && (
           <View style={styles.right} pointerEvents="none">
@@ -127,7 +147,7 @@ export const Input = forwardRef<TextInput, InputProps>(
         )}
         {placeholder && (
           <Animated.View
-            style={[styles.label, { top: labelTop }]}
+            style={[styles.label, disabledLabelStyle, { top: labelTop }]}
             pointerEvents="none"
           >
             <Animated.Text style={{ fontSize: labelFontSize }}>

--- a/packages/design-system/src/atoms/input/index.tsx
+++ b/packages/design-system/src/atoms/input/index.tsx
@@ -1,5 +1,5 @@
 import { View } from 'native-base'
-import { forwardRef, ReactNode, useEffect, useRef } from 'react'
+import { forwardRef, ReactNode, useEffect, useRef, useState } from 'react'
 import { Animated, TextInput, TextInputProps } from 'react-native'
 import { useTheme } from '../../hooks'
 import {
@@ -9,10 +9,12 @@ import {
   makeStyles,
   padding,
 } from '../../styles'
+import { convertTextToNumeric } from '../../utils'
 
 export interface InputProps extends TextInputProps {
   right?: ReactNode
   disabled?: boolean
+  type?: 'text' | 'number'
 }
 
 const styles = makeStyles({
@@ -45,14 +47,21 @@ export const Input = forwardRef<TextInput, InputProps>(
       editable = true,
       onFocus,
       onBlur,
+      onChangeText,
+      type,
       ...rest
     },
     ref,
   ) => {
+    const [controlledValue, setControlledValue] = useState<string>(value ?? '')
     const theme = useTheme()
     const isEmpty = !value || value.length === 0
     const labelTop = useRef(new Animated.Value(0)).current
     const labelFontSize = useRef(new Animated.Value(14)).current
+
+    useEffect(() => {
+      setControlledValue(value ?? '')
+    }, [value])
 
     const isEnabledAndEditable = !disabled && editable
 
@@ -100,6 +109,17 @@ export const Input = forwardRef<TextInput, InputProps>(
       }
     }
 
+    const handleChangeText: InputProps['onChangeText'] = (text) => {
+      if (type === 'number') {
+        const numericText = convertTextToNumeric(text)
+        setControlledValue(numericText)
+        onChangeText?.(numericText)
+      } else {
+        setControlledValue(text)
+        onChangeText?.(text)
+      }
+    }
+
     useEffect(() => {
       if (!isEmpty) {
         scaleLabelDown()
@@ -135,10 +155,11 @@ export const Input = forwardRef<TextInput, InputProps>(
             container.borderRadiusSM,
             container.fullWidth,
           ]}
-          value={value}
           onFocus={handleFocus}
           onBlur={handleBlur}
+          onChangeText={handleChangeText}
           editable={isEnabledAndEditable}
+          value={controlledValue}
         />
         {right && (
           <View style={styles.right} pointerEvents="none">

--- a/packages/design-system/src/atoms/input/input.stories.tsx
+++ b/packages/design-system/src/atoms/input/input.stories.tsx
@@ -12,6 +12,10 @@ const Template = (props: InputProps) => <Input {...props} />
 export const Default = fromTemplate(Template, {
   placeholder: 'Input a text',
 })
+export const Numeric = fromTemplate(Template, {
+  placeholder: 'Input a number',
+  type: 'number',
+})
 export const WithRight = fromTemplate(Template, {
   placeholder: 'Input a text',
   right: <ArrowDownCircle />,

--- a/packages/design-system/src/atoms/input/input.stories.tsx
+++ b/packages/design-system/src/atoms/input/input.stories.tsx
@@ -16,9 +16,14 @@ export const WithRight = fromTemplate(Template, {
   placeholder: 'Input a text',
   right: <ArrowDownCircle />,
 })
-export const Disabled = fromTemplate(Template, {
+export const NonEditable = fromTemplate(Template, {
   placeholder: 'Input a text',
   editable: false,
+})
+export const Disabled = fromTemplate(Template, {
+  placeholder: 'Input a text',
+  value: 'Anything',
+  disabled: true,
 })
 
 export default storyConfig

--- a/packages/design-system/src/atoms/input/input.test.tsx
+++ b/packages/design-system/src/atoms/input/input.test.tsx
@@ -3,7 +3,7 @@ import { TryrollTestProvider } from '../../providers'
 import { Input } from '.'
 
 describe('Input', () => {
-  it('renders editable', async () => {
+  it('changes text', async () => {
     const onChangeText = jest.fn()
     const placeholder = 'Foo'
     render(
@@ -29,7 +29,7 @@ describe('Input', () => {
     expect(onChangeText).toHaveBeenCalledWith(text)
   })
 
-  it('renders disabled', async () => {
+  it("doesn't change disabled", async () => {
     const onChangeText = jest.fn()
     const placeholder = 'Foo'
     render(
@@ -54,7 +54,7 @@ describe('Input', () => {
     expect(input.props.editable).toBe(false)
   })
 
-  it('renders non-editable', async () => {
+  it("doesn't change non-editable", async () => {
     const onChangeText = jest.fn()
     const placeholder = 'Foo'
     render(
@@ -77,5 +77,36 @@ describe('Input', () => {
 
     // RTL triggers onChangeText for non-editable, so we have to check for prop value here
     expect(input.props.editable).toBe(false)
+  })
+
+  it("doesn't allow non-numeric for number", async () => {
+    const onChangeText = jest.fn()
+    const placeholder = 'Foo'
+    render(
+      <Input
+        placeholder={placeholder}
+        type="number"
+        testID="textInput"
+        onChangeText={onChangeText}
+      />,
+      {
+        wrapper: TryrollTestProvider,
+      },
+    )
+
+    const foundPlaceholder = screen.queryByText(placeholder)
+    expect(foundPlaceholder).toBeDefined()
+
+    const input = await screen.findByTestId('textInput')
+    expect(input).toBeDefined()
+
+    fireEvent.changeText(input, 'abc')
+    expect(onChangeText).toHaveBeenCalledWith('')
+
+    fireEvent.changeText(input, 'abc123')
+    expect(onChangeText).toHaveBeenCalledWith('123')
+
+    fireEvent.changeText(input, '467')
+    expect(onChangeText).toHaveBeenCalledWith('467')
   })
 })

--- a/packages/design-system/src/atoms/input/input.test.tsx
+++ b/packages/design-system/src/atoms/input/input.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen } from '@testing-library/react-native'
+import { TryrollTestProvider } from '../../providers'
+import { Input } from '.'
+
+describe('Input', () => {
+  it('renders editable', async () => {
+    const onChangeText = jest.fn()
+    const placeholder = 'Foo'
+    render(
+      <Input
+        placeholder={placeholder}
+        testID="textInput"
+        onChangeText={onChangeText}
+      />,
+      {
+        wrapper: TryrollTestProvider,
+      },
+    )
+
+    const foundPlaceholder = await screen.findByText(placeholder)
+    expect(foundPlaceholder).toBeDefined()
+
+    const input = await screen.findByTestId('textInput')
+    expect(input).toBeDefined()
+
+    const text = 'Change is here'
+    fireEvent.changeText(input, text)
+
+    expect(onChangeText).toHaveBeenCalledWith(text)
+  })
+
+  it('renders disabled', async () => {
+    const onChangeText = jest.fn()
+    const placeholder = 'Foo'
+    render(
+      <Input
+        placeholder={placeholder}
+        disabled
+        testID="textInput"
+        onChangeText={onChangeText}
+      />,
+      {
+        wrapper: TryrollTestProvider,
+      },
+    )
+
+    const foundPlaceholder = await screen.findByText(placeholder)
+    expect(foundPlaceholder).toBeDefined()
+
+    const input = await screen.findByTestId('textInput')
+    expect(input).toBeDefined()
+
+    // RTL triggers onChangeText for non-editable, so we have to check for prop value here
+    expect(input.props.editable).toBe(false)
+  })
+
+  it('renders non-editable', async () => {
+    const onChangeText = jest.fn()
+    const placeholder = 'Foo'
+    render(
+      <Input
+        placeholder={placeholder}
+        editable={false}
+        testID="textInput"
+        onChangeText={onChangeText}
+      />,
+      {
+        wrapper: TryrollTestProvider,
+      },
+    )
+
+    const foundPlaceholder = screen.queryByText(placeholder)
+    expect(foundPlaceholder).toBeDefined()
+
+    const input = await screen.findByTestId('textInput')
+    expect(input).toBeDefined()
+
+    // RTL triggers onChangeText for non-editable, so we have to check for prop value here
+    expect(input.props.editable).toBe(false)
+  })
+})

--- a/packages/design-system/src/molecules/select/index.tsx
+++ b/packages/design-system/src/molecules/select/index.tsx
@@ -2,7 +2,7 @@ import { Pressable, View } from 'native-base'
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { Platform, StyleProp, TextInput, ViewStyle } from 'react-native'
 import ArrowDownCircle from '../../assets/svg/arrowDownCircle.svg'
-import { Body, Popover, Input } from '../../atoms'
+import { Body, Popover, Input, PopoverProps } from '../../atoms'
 import { useTheme } from '../../hooks'
 import { makeStyles, padding } from '../../styles'
 
@@ -70,7 +70,7 @@ export const Select = ({
     [selectedOption],
   )
 
-  const renderReference = useCallback(
+  const renderReference: PopoverProps['renderReference'] = useCallback(
     ({ reference, getReferenceProps }) => {
       const referenceProps = getReferenceProps()
       const inputProps = Platform.select({

--- a/packages/design-system/src/utils/converters.ts
+++ b/packages/design-system/src/utils/converters.ts
@@ -1,0 +1,2 @@
+export const convertTextToNumeric = (text: string): string =>
+  text.replace(/[^0-9]/g, '')

--- a/packages/design-system/src/utils/index.ts
+++ b/packages/design-system/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './formatters'
 export * from './functions'
 export * from './web3'
+export * from './converters'


### PR DESCRIPTION
## What's done

- Added disabled state for `Input`.
- Added `number` type for `Input`.

## How to test

1. `yarn start`
2. Go to `Input` => `Disabled`.
3. Ensure that the input is not editable.
4. Ensure that the input has gray color.
5. Go to `Input` => `Numeric`.
6. Ensure that it allows only numbers to be entered.

## Tasks

- [x] Have you written tests for new code (if applicable)?
- [x] Have you tested the changes on all the platforms?
  - [x] iOS
  - [x] Android
  - [x] Web
- [x] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)

<img width="1422" alt="Screenshot 2023-04-05 at 11 08 41" src="https://user-images.githubusercontent.com/17337276/229986273-c9d9d96f-13d8-41c4-a36e-3636b7d2d8a4.png">
