### PR TITLE
Fix SVG rendering

### DIFF
--- a/.changeset/chatty-timers-occur.md
+++ b/.changeset/chatty-timers-occur.md
@@ -1,0 +1,5 @@
+---
+'@tryrolljs/design-system': patch
+---
+
+Fix SVG rendering

--- a/packages/design-system/rollup.config.js
+++ b/packages/design-system/rollup.config.js
@@ -97,7 +97,7 @@ const getConfig = (format, target = 'web', visualize = false) => {
         include: ['**/*.ttf'],
         limit: Infinity,
       }),
-      image(),
+      image({ exclude: ['**/*.svg'] }),
       svgr({
         native: true,
         icon: true,


### PR DESCRIPTION
## What's done

- Fixed SVG rendering by excluding SVG files from rollup image plugin.

## How to test

## Tasks

- [ ] Have you written tests for new code (if applicable)?
- [ ] Have you tested the changes on all the platforms?
  - [ ] iOS
  - [ ] Android
  - [ ] Web
- [ ] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)
