### PR TITLE
Remove uniswap widget css import & add native fallback

### DIFF
--- a/.changeset/small-cups-trade.md
+++ b/.changeset/small-cups-trade.md
@@ -1,0 +1,5 @@
+---
+'@tryrolljs/design-system': patch
+---
+
+Remove uniswap widget css import & add native fallback

--- a/packages/design-system/src/organisms/uniswapWidget/index.d.ts
+++ b/packages/design-system/src/organisms/uniswapWidget/index.d.ts
@@ -1,0 +1,4 @@
+import type { ComponentType } from 'react'
+import type { SwapWidgetProps } from '@uniswap/widgets'
+
+export const UniswapWidget: ComponentType<SwapWidgetProps>

--- a/packages/design-system/src/organisms/uniswapWidget/index.native.tsx
+++ b/packages/design-system/src/organisms/uniswapWidget/index.native.tsx
@@ -1,0 +1,1 @@
+export const UniswapWidget = () => null

--- a/packages/design-system/src/organisms/uniswapWidget/index.web.tsx
+++ b/packages/design-system/src/organisms/uniswapWidget/index.web.tsx
@@ -1,6 +1,5 @@
 import { SwapWidget, SwapWidgetProps } from '@uniswap/widgets'
 import { useWebSocketProvider } from '../../hooks/web3Wagmi'
-import '@uniswap/widgets/fonts.css'
 
 // Default token list from Uniswap
 const UNISWAP_TOKEN_LIST = 'https://gateway.ipfs.io/ipns/tokens.uniswap.org'

--- a/packages/design-system/src/organisms/uniswapWidget/uniswapWidget.stories.tsx
+++ b/packages/design-system/src/organisms/uniswapWidget/uniswapWidget.stories.tsx
@@ -4,7 +4,7 @@ import { ConnectWeb3OptionsWagmi } from '../../molecules/connectWeb3OptionsWagmi
 import { Web3ProviderWagmi } from '../../providers'
 import { CHAIN_ID_MAIN_NET } from '../../web3'
 import { ConnectWeb3ButtonWagmi } from '../../molecules/connectWeb3ButtonWagmi'
-import { UniswapWidget } from '.'
+import { UniswapWidget } from './index'
 
 const storyConfig = {
   title: titleBuilder.organisms('UniswapWidget'),


### PR DESCRIPTION
## What's done

- Removed uniswap widget css import & added a native fallback

## How to test

## Tasks

- [ ] Have you written tests for new code (if applicable)?
- [ ] Have you tested the changes on all the platforms?
  - [ ] iOS
  - [ ] Android
  - [ ] Web
- [ ] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)
