### PR TITLE
Fix api client never resolves requests because of queue destroy

### DIFF
--- a/.changeset/dry-zoos-hang.md
+++ b/.changeset/dry-zoos-hang.md
@@ -1,0 +1,5 @@
+---
+'@tryrolljs/api-client': minor
+---
+
+Fix api client never resolves requests because of queue destroy

--- a/packages/api-client/src/errors.ts
+++ b/packages/api-client/src/errors.ts
@@ -1,0 +1,8 @@
+const COULDNT_REFRESH_TOKENS = "Couldn't refresh tokens."
+
+export class CouldntRefreshTokens extends Error {
+  constructor() {
+    super(COULDNT_REFRESH_TOKENS)
+    Object.setPrototypeOf(this, new.target.prototype)
+  }
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,2 +1,3 @@
 export * as types from './types'
+export * as errors from './errors'
 export { default } from './client'


### PR DESCRIPTION
## What's done

- Added `onDestroy` callback that will reject when refresh tokens is unsuccessful.

## How to test

## Tasks

- [ ] Have you written tests for new code (if applicable)?
- [ ] Have you tested the changes on all the platforms?
  - [ ] iOS
  - [ ] Android
  - [ ] Web
- [ ] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)
