### PR TITLE
Fix session provider token generation

### DIFF
--- a/.changeset/odd-ways-hope.md
+++ b/.changeset/odd-ways-hope.md
@@ -1,0 +1,5 @@
+---
+'@roll-network/session-manager': minor
+---
+
+Fixed token generation within session-provider

--- a/packages/session-manager/src/native-session-provider.tsx
+++ b/packages/session-manager/src/native-session-provider.tsx
@@ -54,7 +54,7 @@ const NativeSessionProvider = ({
         const [_, query] = url.split('?')
         const { code } = parse(query)
         if (typeof code === 'string') {
-          await authSdk.generateToken({ code })
+          await authSdk.generateToken(code)
           const me = await userAPI.getMe(apiClient)
           setUser(me.data)
         }

--- a/packages/session-manager/src/session-provider.test.tsx
+++ b/packages/session-manager/src/session-provider.test.tsx
@@ -85,7 +85,7 @@ describe('useSession', () => {
     })
 
     await waitFor(() => {
-      expect(generateToken).toHaveBeenCalledWith({ code: oauthCode })
+      expect(generateToken).toHaveBeenCalledWith(oauthCode)
       expect(result.current.user).toBe(user)
     })
   })
@@ -116,7 +116,7 @@ describe('useSession', () => {
     })
 
     await waitFor(() => {
-      expect(generateToken).toHaveBeenCalledWith({ code: oauthCode })
+      expect(generateToken).toHaveBeenCalledWith(oauthCode)
       expect(result.current.user).toBe(undefined)
       expect(result.current.error).toBe(error)
     })

--- a/packages/session-manager/src/session-provider.tsx
+++ b/packages/session-manager/src/session-provider.tsx
@@ -66,7 +66,7 @@ const SessionProvider = ({
       try {
         const oauthCode = getOauthCode()
         if (oauthCode) {
-          await authSdk.generateToken({ code: oauthCode })
+          await authSdk.generateToken(oauthCode)
           await loadUserData()
         }
       } catch (e) {


### PR DESCRIPTION
## What's done

- Fixed session provider token generation.
- Currently, it passes an object to `generateToken`. Instead, we need to have a plain code string.

## How to test

`yarn test`

## Tasks

- [ ] Have you written tests for new code (if applicable)?
- [ ] Have you tested the changes on all the platforms?
  - [ ] iOS
  - [ ] Android
  - [ ] Web
- [ ] Have you added stories to demonstrate the new functionality (if there is any)?

## Demo (screenshots, recordings, etc.)

https://www.loom.com/share/122b501891684db99ec814cc4f1af6b3
